### PR TITLE
Update Systemd-Unit-File.md

### DIFF
--- a/Systemd-Unit-File.md
+++ b/Systemd-Unit-File.md
@@ -1,5 +1,7 @@
 Aside from the provided pm2 instructions. You can also use systemd to enable and run Uptime-Kuma at system startup more easily.
 
+Place the following file in /etc/systemd/system/, and name it uptime.service.
+
 ```ini
 [Unit]
 Description=Uptime-Kuma - A free and open source uptime monitoring solution
@@ -8,16 +10,23 @@ After=network.target
 
 [Service]
 Type=simple
-User=uptime
-WorkingDirectory=/home/uptime/uptime-kuma
-ExecStart=/usr/bin/npm run start-server
-Restart=on-failure
 
+WorkingDirectory=/opt/uptime-kuma
+
+ReadWriteDirectories=/opt/uptime-kuma /var/log
+
+ExecStart=/usr/bin/npm run start-server
+ExecStop=/usr/bin/npm run stop-server
+
+Restart=on-failure
+. 
 [Install]
 WantedBy=multi-user.target
 ```
 
-Note: This unit file assumes that you are running the software as a separate 'uptime' user. If you have node/npm installed in a different path, you will need to alter the ExecStart line to match this.
+Note: This unit file assumes that you are running the software under root privileges. These are necessary in order to use the ping and socket capabilities of the linux kernel. See: https://stackoverflow.com/questions/9772068/raw-socket-access-as-normal-user-on-linux-2-4.
+
+If you have node/npm installed in a different path, you will need to alter the ExecStart line to match this.
 
 This unit file may be installed to /etc/systemd/system/uptime-kuma.service (Or whatever service name you'd prefer)
 
@@ -25,5 +34,6 @@ Once installed, issue the following commands to reload systemd unit files, enabl
 
 ```sh
 systemctl daemon-reload
-systemctl enable --now uptime-kuma
+systemctl start uptime
+systemctl enable uptime
 ```


### PR DESCRIPTION
Added ExecStop commands as they were missing. 

Changed default directory to '/opt/uptime-kuma' as it that is where the installer defaulted to in install.sh and will save the user having to manually make that change.

Removed the 'uptime' user requirement as that installation method isn't viable. This is due to, as I understand, the necessity of root privileges being required in order to use socket capabilities in the linux kernel via CAP_NET_RAW. 

I have followed advice on setting the setuid bit for the process, that wasn't a good work around as it was a heavy security risk. I also tried granting the process and related server.js file the CAP_NET_RAW capability via the following command: 'setcap cap_net_raw+ep <file_name>' to no avail.

See the following for more info on that subject:
- https://stackoverflow.com/questions/20763039/creating-raw-socket-in-python-without-root-privileges.
- https://serverfault.com/questions/390153/which-permission-is-needed-to-open-a-tcp-server-socket-on-linux
- https://stackoverflow.com/questions/9772068/raw-socket-access-as-normal-user-on-linux-2-4